### PR TITLE
Allow hydra-check to fail builds as we categorize them in jq

### DIFF
--- a/nixpkgs-health-check-by-maintainer.toml
+++ b/nixpkgs-health-check-by-maintainer.toml
@@ -3,9 +3,6 @@
 [skip]
 pinact = { nixpkgs-update = "https://github.com/NixOS/nixpkgs/pull/472064" }
 typescript-go = { nixpkgs-update = "https://github.com/NixOS/nixpkgs/pull/490934" }
-ameba-ls = { hydra = "Dependency failure" }
-yaneuraou = { hydra = "Dependency failure" }
-html2pdf = { hydra = "bbcb8b80cb89a7a72e731ed825d66bd5167a0d2a should consider https://github.com/nix-community/hydra-check/pull/94" }
 
 # For testing
 hello = { hydra = "Test skip", nixpkgs-update = "Test skip" }

--- a/pkgs/nixpkgs-health-check-hydra/package.nix
+++ b/pkgs/nixpkgs-health-check-hydra/package.nix
@@ -11,11 +11,16 @@ writeShellApplication {
     jq
     coreutils
   ];
+  # hydra-check 2.1.0 returns 1 if there are any build failures in the evaluation.
+  # We ignore this exit code because we categorize failures (e.g. Dependency failed)
+  # as warnings in the next jq step.
+  # See https://github.com/nix-community/hydra-check/pull/94
   text = ''
     PNAME="$1"
 
     mkdir -p tmp
-    hydra-check --json --channel=nixpkgs-unstable --eval "$PNAME" | tee tmp/raw_hydra.json
+    hydra-check --json --channel=nixpkgs-unstable --eval "$PNAME" > tmp/raw_hydra.json || true
+    cat tmp/raw_hydra.json
     jq --from-file ${./normalize-hydra-eval.jq} tmp/raw_hydra.json | tee tmp/normalized_hydra.json
 
     if jq -e '.[] | select(.severity == "error")' tmp/normalized_hydra.json > tmp/hydra_errors.jsonl; then


### PR DESCRIPTION
hydra-check 2.1.0 returns exit code 1
if there are any build failures in the evaluation.
This caused the Action to abort before our subsequent jq step could categorize
those failures (e.g., treating 'Dependency failed' as a warning).

This change bypasses the exit code in the shell script and moves the explanation
to a Nix-level comment to minimize script rebuilds.
Also removed packages from the skip list that are now correctly handled.
